### PR TITLE
Fix issues with CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.csl text eol=lf
+*.go text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
 
       - name: Test (PR)
         if: ${{ github.event_name == 'pull_request' }}
-        run: gotestsum --format testname -- -race -coverprofile=coverage.txt -covermode=atomic ./...
+        run: gotestsum --format testname -- -race -coverprofile='coverage.txt' -covermode=atomic ./...
 
       - name: Test (Full)
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
-        run: gotestsum --format testname -- -race -coverprofile=coverage.txt -covermode=atomic ./...
+        run: gotestsum --format testname -- -race -coverprofile='coverage.txt' -covermode=atomic ./...
         env:
           KSD_TEST_CLIENT_SECRET: ${{ secrets.KSD_TEST_CLIENT_SECRET }}
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Build
         run: go build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
       
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3 
-     
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
         with:
           name: ${{ matrix.artifact }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,17 @@ jobs:
 
       - name: Test (PR)
         if: ${{ github.event_name == 'pull_request' }}
-        run: gotestsum --format testname
+        run: gotestsum --format testname -- -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Test (Full)
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
-        run: gotestsum --format testname
+        run: gotestsum --format testname -- -race -coverprofile=coverage.txt -covermode=atomic ./...
         env:
           KSD_TEST_CLIENT_SECRET: ${{ secrets.KSD_TEST_CLIENT_SECRET }}
       
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3 
+     
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,16 @@ jobs:
       - name: Build
         run: go build
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Test (PR)
         if: ${{ github.event_name == 'pull_request' }}
-        run: go test -v ./...
+        run: gotestsum --format testname
 
       - name: Test (Full)
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
-        run: go test -v ./...
+        run: gotestsum --format testname
         env:
           KSD_TEST_CLIENT_SECRET: ${{ secrets.KSD_TEST_CLIENT_SECRET }}
       

--- a/internal/ksd/.snapshots/.gitattributes
+++ b/internal/ksd/.snapshots/.gitattributes
@@ -1,0 +1,1 @@
+*.csl text eol=lf

--- a/internal/ksd/.snapshots/.gitattributes
+++ b/internal/ksd/.snapshots/.gitattributes
@@ -1,1 +1,0 @@
-*.csl text eol=lf

--- a/internal/ksd/build_test.go
+++ b/internal/ksd/build_test.go
@@ -3,6 +3,7 @@ package ksd
 import (
 	"embed"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -37,7 +38,7 @@ func testBuild(t *testing.T, root string, prefix string) {
 
 		e := e
 		t.Run(e.Name(), func(t *testing.T) {
-			bytes, err := testData.ReadFile(filepath.Join(root, e.Name()))
+			bytes, err := testData.ReadFile(path.Join(root, e.Name()))
 			require.NoError(t, err)
 			reader := strings.NewReader(string(bytes))
 

--- a/test/sync_test.go
+++ b/test/sync_test.go
@@ -1,4 +1,4 @@
-package examples
+package test
 
 import (
 	"fmt"


### PR DESCRIPTION
Fix wrong `go` version being installed (1.2 instead of 1.20).
Fix snapshot test on windows (due to line ending differences).
Add code coverage.